### PR TITLE
feat: Migrate to grammar-based parser.

### DIFF
--- a/zql_api/main.py
+++ b/zql_api/main.py
@@ -10,7 +10,7 @@ from zql import Zql, ZqlParserError
 from fastapi.middleware.cors import CORSMiddleware
 
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
-USE_GRAMMAR = False
+USE_GRAMMAR = True
 
 def setup_db(session):
     session.execute("DROP TABLE IF EXISTS peeps;")


### PR DESCRIPTION
The grammar-based parser represents the ZQL dialect as a finite state machine encoded in a `.tmjd` file. This file also encodes how to render certain lines in the target language, if it should not be done implicitly.

See `zql/zql_grammar.tmjd` for the grammar.

The grammar-based parser can evaluate this finite state machine to convert source code into an abstract syntax tree and then the grammar renderer can convert the abstract syntax tree to a concrete query in the target language.

Through unit and integration tests, we have demonstrated that this parser achieves parity with and goes beyond the feature set of the previous parser. It also supplies numerous bug fixes and brings the data definitional language (DDL) and data manipulation language (DML) to ZQL.

The syntax error messages from this new parser are still a work in progress and we might encounter issues from operations that mutate our database. We will continue to improve and monitor those post-migration.

At anytime, we can switch back to the old parser by flipping the flag off. After we have finalized the launch, we will clean up the old parser and renderer.